### PR TITLE
Fix ModelOpt glob exclude matching

### DIFF
--- a/python/sglang/srt/layers/quantization/utils.py
+++ b/python/sglang/srt/layers/quantization/utils.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import re
 from copy import deepcopy
+from fnmatch import fnmatchcase
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Tuple, Union
 
@@ -54,8 +55,11 @@ def _module_path_match(ignored: str, prefix: str) -> bool:
     # match `mlp.gate_up_proj`. Needed for quant configs (e.g. Qwen3.6-FP8)
     # whose `modules_to_not_convert` lists MoE-template names like `mlp.gate`
     # that collide with fused dense MLP names by plain substring.
-    ignored = ignored.rstrip(".")
-    prefix = prefix.rstrip(".")
+    ignored = normalize_prefix(ignored.rstrip("."))
+    prefix = normalize_prefix(prefix.rstrip("."))
+    if any(char in ignored for char in "*?["):
+        candidates = (prefix, prefix if prefix.startswith("model.") else f"model.{prefix}")
+        return any(fnmatchcase(candidate, ignored) for candidate in candidates)
     if ignored == prefix:
         return True
     if prefix.startswith(ignored + "."):

--- a/test/registered/quant/test_is_layer_skipped.py
+++ b/test/registered/quant/test_is_layer_skipped.py
@@ -58,6 +58,24 @@ class TestIsLayerSkipped(CustomTestCase):
             is_layer_skipped("model.layers.340.mlp.experts.0.down_proj", ignored, {})
         )
 
+    def test_glob_patterns_skip_fused_qkv(self):
+        ignored = [
+            "*.self_attn.q_proj",
+            "*.self_attn.k_proj",
+            "*.self_attn.v_proj",
+        ]
+        self.assertTrue(
+            is_layer_skipped("model.layers.3.self_attn.qkv_proj", ignored, {})
+        )
+        self.assertFalse(
+            is_layer_skipped("model.layers.3.self_attn.o_proj", ignored, {})
+        )
+
+    def test_model_prefixed_glob_matches_normalized_prefix(self):
+        self.assertTrue(
+            is_layer_skipped("model.visual.encoder.proj", ["model.visual.*"], {})
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- support shell-style glob entries in ModelOpt `ignore` / exclude lists;
- normalize a leading `model.` prefix before matching;
- preserve the existing exact-name and child-prefix behavior.

## Why

Some ModelOpt checkpoints use entries such as `*.self_attn.q_proj`.  The current exact/prefix-only matcher misses those entries and can allocate a quantized parameter for a checkpoint tensor that was intentionally left unquantized.  This showed up while validating GLM-5.3 NVFP4 NextN loading, but the matcher fix is model-independent.

## Tests

```text
python test/registered/quant/test_is_layer_skipped.py -v
Ran 6 tests ... OK
```

The added coverage includes glob matching, normalized `model.` prefixes, child-prefix matching, and false-positive protection.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #33091287047](https://github.com/guqiong96/Lsglang/actions/runs/33091287047)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #33091286715](https://github.com/guqiong96/Lsglang/actions/runs/33091286715)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->