### PR TITLE
[SM120] Support GLM-5.3 NoPE sparse MLA

### DIFF
--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -28,6 +28,8 @@ _is_hip = is_hip()
 _GLM_DSA_MODEL_ARCHS = (
     "GlmMoeDsaForCausalLM",
     "GlmMoeDsaForCausalLMNextN",
+    "Glm5NextForConditionalGeneration",
+    "Glm5NextForConditionalGenerationNextN",
 )
 
 # Page layout constants for DSv4-Flash (MODEL1):
@@ -710,13 +712,42 @@ def flashinfer_sparse_mla_forward(
     qk_nope_head_dim: int,
     kv_lora_rank: int,
     qk_rope_head_dim: int,
+    sparse_mla_top_k: int,
     sm_scale: float,
     skip_softmax_threshold_scale_factor: float | None,
 ) -> torch.Tensor:
     """Run FlashInfer's SM120 sparse MLA kernel on SGLang's packed DSA cache."""
     from flashinfer.mla import trtllm_batch_decode_with_kv_cache_mla
 
-    topk = indices.shape[1]
+    topk_capacity = sparse_mla_top_k
+    kernel_qk_rope_head_dim = qk_rope_head_dim
+    empty_rows = None
+    sparse_mla_top_k_lens = None
+    if qk_rope_head_dim == 0:
+        from sglang.kernels.ops.attention.dsa.transform_index import (
+            prepare_trtllm_nope_sparse_metadata,
+        )
+
+        sparse_mla_top_k_lens = prepare_trtllm_nope_sparse_metadata(indices)
+        # The SM120 kernel inventory has only the DeepSeek 576-wide query /
+        # 64-wide RoPE geometry.  Appending zeros presents that geometry while
+        # preserving GLM-5.3's native NoPE math.
+        q = torch.nn.functional.pad(q, (0, 64))
+        kernel_qk_rope_head_dim = 64
+
+        # index_kpool may reserve overflow columns for an in-progress tail.
+        # The compiled kernel accepts exactly index_topk columns.  KPool now
+        # compacts the tail inside this capacity; keep this guard for old or
+        # graph-captured buffers.
+        if indices.shape[1] > topk_capacity:
+            indices = indices[:, :topk_capacity].contiguous()
+            sparse_mla_top_k_lens = sparse_mla_top_k_lens.clamp(max=topk_capacity)
+
+        empty_rows = sparse_mla_top_k_lens == 0
+        indices[:, 0] = indices[:, 0].masked_fill(empty_rows, 0)
+        seq_lens = sparse_mla_top_k_lens.clamp(min=1)
+
+    topk_capacity = min(topk_capacity, indices.shape[1])
     result = trtllm_batch_decode_with_kv_cache_mla(
         query=q.unsqueeze(1),
         kv_cache=kv_cache.view(torch.uint8)
@@ -725,14 +756,23 @@ def flashinfer_sparse_mla_forward(
         workspace_buffer=workspace_buffer,
         qk_nope_head_dim=qk_nope_head_dim,
         kv_lora_rank=kv_lora_rank,
-        qk_rope_head_dim=qk_rope_head_dim,
+        qk_rope_head_dim=kernel_qk_rope_head_dim,
         block_tables=indices.unsqueeze(1),
         seq_lens=seq_lens,
-        max_seq_len=topk,
-        sparse_mla_top_k=topk,
+        max_seq_len=topk_capacity,
+        sparse_mla_top_k=topk_capacity,
+        # Once the NoPE tensors are padded to the DeepSeek RoPE64 geometry,
+        # FlashInfer selects the compiled RoPE64 kernel.  Its active lengths
+        # are carried by seq_lens; the native-NoPE-only metadata argument must
+        # stay unset or the public wrapper rejects the call before dispatch.
+        sparse_mla_top_k_lens=None,
         bmm1_scale=float(sm_scale),
         bmm2_scale=1.0,
         kv_scale_format="arbitrary_fp32",
         skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
+        enable_pdl=False,
     )
-    return result.squeeze(1)
+    result = result.squeeze(1)
+    if empty_rows is not None:
+        result.masked_fill_(empty_rows.view(-1, 1, 1), 0.0)
+    return result

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer_kpool.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer_kpool.py
@@ -1176,8 +1176,9 @@ class IndexerKPool(MultiPlatformOp):
         page_size = get_token_to_kv_pool().page_size
         token_nums = q_fp8.shape[0]
         tail_pool = pool_size - 1
-        topk_result = torch.empty(
-            (token_nums, self.index_topk + tail_pool),
+        topk_result = torch.full(
+            (token_nums, self.index_topk),
+            -1,
             device=q_fp8.device,
             dtype=torch.int32,
         )

--- a/python/sglang/srt/layers/attention/dsa/kpool_fp8_index.py
+++ b/python/sglang/srt/layers/attention/dsa/kpool_fp8_index.py
@@ -438,9 +438,16 @@ def append_kpool_tail_to_topk(
         return topk_result
 
     rows, n_cols = topk_result.shape
-    out_cols = n_cols + tail_pool
-    out = torch.empty(
-        (rows, out_cols), dtype=topk_result.dtype, device=topk_result.device
+    # Keep the expanded history and the in-progress tail inside the model's
+    # fixed index_topk capacity.  For GLM (topk=2048, kpool=4), retain 2044
+    # history slots, append up to three tail tokens, and leave one -1 sentinel.
+    out_cols = n_cols
+    history_capacity = ((out_cols - tail_pool) // pool_size) * pool_size
+    out = torch.full(
+        (rows, out_cols),
+        -1,
+        dtype=topk_result.dtype,
+        device=topk_result.device,
     )
 
     if page_table is None:
@@ -478,6 +485,7 @@ def append_kpool_tail_to_topk(
         out.stride(1),
         N_COLS=n_cols,
         OUT_COLS=out_cols,
+        HISTORY_CAPACITY=history_capacity,
         PAGE_TABLE_COLS=page_table_cols,
         POOL_SIZE=pool_size,
         HAS_PAGE_TABLE=has_page_table,
@@ -503,6 +511,7 @@ def _append_kpool_tail_to_topk_kernel(
     out_stride_1,
     N_COLS: tl.constexpr,
     OUT_COLS: tl.constexpr,
+    HISTORY_CAPACITY: tl.constexpr,
     PAGE_TABLE_COLS: tl.constexpr,
     POOL_SIZE: tl.constexpr,
     HAS_PAGE_TABLE: tl.constexpr,
@@ -516,7 +525,7 @@ def _append_kpool_tail_to_topk_kernel(
     seq_len = tl.load(seq_lens_ptr + row).to(tl.int32)
     pool_len = tl.load(pool_lens_ptr + row).to(tl.int32)
     tail_start = pool_len * POOL_SIZE
-    history_len = tl.minimum(tail_start, N_COLS)
+    history_len = tl.minimum(tail_start, HISTORY_CAPACITY)
     tail_count = seq_len % POOL_SIZE
 
     is_history = cols < history_len

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -877,12 +877,12 @@ class DeepseekSparseAttnBackend(
         if (
             topk_indices is None
             or self.dsa_index_kpool <= 1
-            or dsa_impl in ("fa3", "tilelang", "trtllm")
+            or dsa_impl in ("fa3", "tilelang", "trtllm", "flashinfer_sparse_mla")
         ):
             return
         raise NotImplementedError(
             "index_kpool > 1 appends tail tokens to topk_indices and is "
-            f"currently only supported by the FA3/TileLang/TRTLLM DSA {phase} "
+            f"currently only supported by the FA3/TileLang/TRTLLM/FlashInfer sparse MLA DSA {phase} "
             "backend."
         )
 
@@ -4002,6 +4002,7 @@ class DeepseekSparseAttnBackend(
             qk_nope_head_dim=self.qk_nope_head_dim,
             kv_lora_rank=self.kv_lora_rank,
             qk_rope_head_dim=self.qk_rope_head_dim,
+            sparse_mla_top_k=self.dsa_index_topk,
             sm_scale=sm_scale,
             skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
         )

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1610,7 +1610,6 @@ class KVCacheConfigurator:
                     kv_cache_dim=calculate_mla_kv_cache_dim(
                         model_config=self.model_config,
                         kv_cache_dtype=self.kv_cache_dtype,
-                        server_args=self.server_args,
                     ),
                     index_kpool=dsa_index_kpool,
                     index_kpool_compress=get_dsa_index_kpool_compress(
@@ -2294,6 +2293,21 @@ def calculate_mla_kv_cache_dim(
 
     quant_block_size = DSATokenToKVPool.quant_block_size
     rope_storage_dtype = DSATokenToKVPool.rope_storage_dtype
+    # FlashInfer's SM120 sparse MLA kernel is compiled for the DeepSeek packed
+    # geometry, which always reserves a 64-wide BF16 RoPE tail.  GLM-5.3 is a
+    # native NoPE model, so reserve the same inert tail in storage and write
+    # zeros into it.  This keeps the existing high-performance kernel usable
+    # without changing GLM's attention scores.
+    uses_flashinfer_sparse_mla = (
+        get_exec().kernel.dsa_prefill_backend == "flashinfer_sparse_mla"
+        or get_exec().kernel.dsa_decode_backend == "flashinfer_sparse_mla"
+    )
+    storage_rope_head_dim = (
+        64
+        if uses_flashinfer_sparse_mla and qk_rope_head_dim == 0
+        else qk_rope_head_dim
+    )
+
     # Calculate override_kv_cache_dim for FP8 storage in backends that use scaled KV layout
     # (excluding TRTLLM and HIP raw-layout kernels).
     # kv_lora_rank + scale storage (kv_lora_rank // quant_block_size * 4 bytes) + rope dimension storage
@@ -2306,7 +2320,7 @@ def calculate_mla_kv_cache_dim(
         return (
             kv_lora_rank
             + kv_lora_rank // quant_block_size * 4
-            + qk_rope_head_dim * rope_storage_dtype.itemsize
+            + storage_rope_head_dim * rope_storage_dtype.itemsize
         )
 
     return kv_cache_dim

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -4474,6 +4474,25 @@ class MLATokenToKVPool(KVCache):
                 fp8_dtype,
             )
         elif self.dsa_kv_cache_store_fp8:
+            # FlashInfer's SM120 sparse MLA cubin expects the packed DeepSeek
+            # layout: 512 FP8 NoPE bytes, four FP32 scales, and a 64-wide BF16
+            # RoPE tail.  GLM-5.3 has no RoPE, so materialize a zero tail when
+            # the configured packed cache reserves it.  The zero block is
+            # mathematically inert in QK dot products.
+            if cache_k_rope is None or cache_k_rope.numel() == 0:
+                scale_bytes = self.kv_lora_rank // self.quant_block_size * 4
+                rope_bytes = self.kv_cache_dim - self.kv_lora_rank - scale_bytes
+                assert rope_bytes >= 0
+                assert rope_bytes % self.rope_storage_dtype.itemsize == 0
+                storage_rope_head_dim = (
+                    rope_bytes // self.rope_storage_dtype.itemsize
+                )
+                if storage_rope_head_dim:
+                    cache_k_rope = cache_k_nope.new_zeros(
+                        (*cache_k_nope.shape[:-1], storage_rope_head_dim),
+                        dtype=self.rope_storage_dtype,
+                    )
+
             # OPTIMIZATION: Quantize k_nope and k_rope separately to avoid concat overhead
             # This also enables reuse of set_mla_kv_buffer_triton two-tensor write path
             # quantize_k_cache_separate returns (nope_part, rope_part) as uint8 bytes

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -98,6 +98,17 @@ _is_cuda = is_cuda()
 _is_npu = is_npu()
 
 
+def _should_clear_modelopt_fp4_nextn_quant_config(
+    config: PretrainedConfig,
+    quant_config: Optional[QuantizationConfig],
+) -> bool:
+    """Keep GLM-5 NextN on its checkpoint-declared ModelOpt NVFP4 path."""
+    if quant_config is None or quant_config.get_name() != "modelopt_fp4":
+        return False
+    architectures = getattr(config, "architectures", None) or []
+    return "Glm5NextForConditionalGenerationNextN" not in architectures
+
+
 class DeepseekModelNextN(nn.Module):
 
     def __init__(
@@ -116,7 +127,7 @@ class DeepseekModelNextN(nn.Module):
         else:
             moe_quant_config_override = None
 
-        if quant_config is not None and quant_config.get_name() == "modelopt_fp4":
+        if _should_clear_modelopt_fp4_nextn_quant_config(config, quant_config):
             logger.warning(
                 "Overriding DeepseekV3ForCausalLMNextN quant config for modelopt_fp4 Deepseek model."
             )

--- a/test/registered/unit/models/test_glm5_next_nextn_weight_loading.py
+++ b/test/registered/unit/models/test_glm5_next_nextn_weight_loading.py
@@ -3,6 +3,9 @@ from types import SimpleNamespace
 
 import torch
 
+from sglang.srt.models.deepseek_nextn import (
+    _should_clear_modelopt_fp4_nextn_quant_config,
+)
 from sglang.srt.models.glm5_next_nextn import (
     Glm5NextForConditionalGenerationNextN,
 )
@@ -20,6 +23,24 @@ class _FakeParam:
 
 
 class TestGlm5NextNextNWeightLoading(unittest.TestCase):
+    def test_keeps_modelopt_fp4_for_glm5_nextn(self):
+        quant_config = SimpleNamespace(get_name=lambda: "modelopt_fp4")
+        glm_config = SimpleNamespace(
+            architectures=["Glm5NextForConditionalGenerationNextN"]
+        )
+        deepseek_config = SimpleNamespace(
+            architectures=["DeepseekV3ForCausalLMNextN"]
+        )
+
+        self.assertFalse(
+            _should_clear_modelopt_fp4_nextn_quant_config(glm_config, quant_config)
+        )
+        self.assertTrue(
+            _should_clear_modelopt_fp4_nextn_quant_config(
+                deepseek_config, quant_config
+            )
+        )
+
     def test_checkpoint_qkv_sources_load_fused_projection(self):
         fused_param = _FakeParam()
         model = SimpleNamespace(

--- a/test/registered/unit/test_flashinfer_sparse_mla.py
+++ b/test/registered/unit/test_flashinfer_sparse_mla.py
@@ -1,6 +1,6 @@
 import sys
 import unittest
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import patch
 
 import torch
@@ -9,6 +9,8 @@ from sglang.kernels.ops.attention.flash_mla_sm120 import (
     _validate_flashinfer_sparse_mla_backend,
     flashinfer_sparse_mla_forward,
 )
+from sglang.srt.mem_cache.kv_cache_configurator import calculate_mla_kv_cache_dim
+from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
@@ -48,6 +50,7 @@ class TestFlashInferSparseMLAAdapter(unittest.TestCase):
                 qk_nope_head_dim=192,
                 kv_lora_rank=512,
                 qk_rope_head_dim=64,
+                sparse_mla_top_k=4,
                 sm_scale=0.125,
                 skip_softmax_threshold_scale_factor=0.25,
             )
@@ -67,9 +70,82 @@ class TestFlashInferSparseMLAAdapter(unittest.TestCase):
         self.assertEqual(captured["bmm2_scale"], 1.0)
         self.assertEqual(captured["kv_scale_format"], "arbitrary_fp32")
         self.assertEqual(captured["skip_softmax_threshold_scale_factor"], 0.25)
+        self.assertFalse(captured["enable_pdl"])
         self.assertNotIn("backend", captured)
+        self.assertIsNone(captured["sparse_mla_top_k_lens"])
         self.assertEqual(tuple(output.shape), (2, 8, 512))
         self.assertTrue(torch.all(output == 2))
+
+    def test_supplies_topk_lengths_for_native_nope_mla(self):
+        captured = {}
+        topk_lens = torch.tensor([2, 3], dtype=torch.int32)
+
+        def fake_op(**kwargs):
+            captured.update(kwargs)
+            query = kwargs["query"]
+            return query.new_zeros((*query.shape[:-1], kwargs["kv_lora_rank"]))
+
+        with self._mock_flashinfer(fake_op), patch(
+            "sglang.kernels.ops.attention.dsa.transform_index.prepare_trtllm_nope_sparse_metadata",
+            return_value=topk_lens,
+        ):
+            flashinfer_sparse_mla_forward(
+                q=torch.zeros((2, 8, 512), dtype=torch.bfloat16),
+                kv_cache=torch.zeros((128, 1, 656), dtype=torch.uint8),
+                indices=torch.tensor([[7, 9, -1], [4, 6, 8]], dtype=torch.int32),
+                seq_lens=torch.tensor([2, 3], dtype=torch.int32),
+                workspace_buffer=torch.zeros(1024, dtype=torch.uint8),
+                page_size=64,
+                kv_cache_dim=656,
+                qk_nope_head_dim=256,
+                kv_lora_rank=512,
+                qk_rope_head_dim=0,
+                sparse_mla_top_k=3,
+                sm_scale=0.125,
+                skip_softmax_threshold_scale_factor=None,
+            )
+
+        self.assertIsNone(captured["sparse_mla_top_k_lens"])
+        self.assertEqual(tuple(captured["query"].shape), (2, 1, 8, 576))
+        self.assertTrue(torch.all(captured["query"][..., 512:] == 0))
+        self.assertEqual(captured["qk_rope_head_dim"], 64)
+        self.assertEqual(captured["seq_lens"].tolist(), [2, 3])
+        self.assertEqual(captured["sparse_mla_top_k"], 3)
+        self.assertFalse(captured["enable_pdl"])
+
+    def test_clamps_kpool_overflow_to_compiled_topk_capacity(self):
+        captured = {}
+        topk_lens = torch.tensor([2051], dtype=torch.int32)
+
+        def fake_op(**kwargs):
+            captured.update(kwargs)
+            query = kwargs["query"]
+            return query.new_zeros((*query.shape[:-1], kwargs["kv_lora_rank"]))
+
+        with self._mock_flashinfer(fake_op), patch(
+            "sglang.kernels.ops.attention.dsa.transform_index.prepare_trtllm_nope_sparse_metadata",
+            return_value=topk_lens,
+        ):
+            flashinfer_sparse_mla_forward(
+                q=torch.zeros((1, 8, 512), dtype=torch.bfloat16),
+                kv_cache=torch.zeros((128, 1, 656), dtype=torch.uint8),
+                indices=torch.arange(2051, dtype=torch.int32).unsqueeze(0),
+                seq_lens=torch.tensor([2051], dtype=torch.int32),
+                workspace_buffer=torch.zeros(1024, dtype=torch.uint8),
+                page_size=64,
+                kv_cache_dim=656,
+                qk_nope_head_dim=256,
+                kv_lora_rank=512,
+                qk_rope_head_dim=0,
+                sparse_mla_top_k=2048,
+                sm_scale=0.125,
+                skip_softmax_threshold_scale_factor=None,
+            )
+
+        self.assertEqual(tuple(captured["block_tables"].shape), (1, 1, 2048))
+        self.assertIsNone(captured["sparse_mla_top_k_lens"])
+        self.assertEqual(captured["seq_lens"].tolist(), [2048])
+        self.assertEqual(captured["max_seq_len"], 2048)
 
 
 class TestFlashInferSparseMLABackendGate(unittest.TestCase):
@@ -86,6 +162,8 @@ class TestFlashInferSparseMLABackendGate(unittest.TestCase):
         for model_arch in (
             "GlmMoeDsaForCausalLM",
             "GlmMoeDsaForCausalLMNextN",
+            "Glm5NextForConditionalGeneration",
+            "Glm5NextForConditionalGenerationNextN",
         ):
             with self.subTest(model_arch=model_arch):
                 self.assertTrue(
@@ -117,6 +195,69 @@ class TestFlashInferSparseMLABackendGate(unittest.TestCase):
         self.assertIn("model_arch='DeepseekV3ForCausalLM'", message)
         self.assertIn("sm_major=12", message)
         self.assertIn("kv_cache_dtype=torch.float8_e4m3fn", message)
+
+
+class TestFlashInferNoPEPackedKV(unittest.TestCase):
+    def test_reserves_deepseek_packed_rope_tail(self):
+        model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(),
+            kv_lora_rank=512,
+            qk_rope_head_dim=0,
+        )
+        exec_context = SimpleNamespace(
+            kernel=SimpleNamespace(
+                dsa_prefill_backend="flashinfer_sparse_mla",
+                dsa_decode_backend="flashinfer_sparse_mla",
+            )
+        )
+        with patch(
+            "sglang.srt.mem_cache.kv_cache_configurator.is_deepseek_dsa",
+            return_value=True,
+        ), patch(
+            "sglang.srt.mem_cache.kv_cache_configurator.get_disagg",
+            return_value=SimpleNamespace(disaggregation_mode=None),
+        ), patch(
+            "sglang.srt.mem_cache.kv_cache_configurator.get_exec",
+            return_value=exec_context,
+        ):
+            kv_cache_dim = calculate_mla_kv_cache_dim(
+                model_config=model_config,
+                kv_cache_dtype=torch.float8_e4m3fn,
+            )
+
+        self.assertEqual(kv_cache_dim, 656)
+
+    def test_writes_zero_rope_tail_for_native_nope(self):
+        pool = object.__new__(MLATokenToKVPool)
+        pool.dsa_kv_cache_store_fp8 = True
+        pool.kv_lora_rank = 512
+        pool.kv_cache_dim = 656
+        pool.quant_block_size = 128
+        pool.rope_storage_dtype = torch.bfloat16
+
+        captured = {}
+
+        def fake_quantize(k_nope, k_rope):
+            captured["rope"] = k_rope
+            return (
+                torch.zeros((2, 1, 528), dtype=torch.uint8),
+                torch.zeros((2, 1, 128), dtype=torch.uint8),
+            )
+
+        with patch(
+            "sglang.srt.mem_cache.memory_pool.quantize_k_cache_separate",
+            side_effect=fake_quantize,
+        ), patch("sglang.srt.mem_cache.memory_pool.set_mla_kv_buffer_triton"):
+            pool._write_mla_kv_buffer(
+                torch.zeros((8, 1, 656), dtype=torch.uint8),
+                torch.tensor([1, 2], dtype=torch.int64),
+                torch.ones((2, 1, 512), dtype=torch.bfloat16),
+                None,
+            )
+
+        self.assertEqual(tuple(captured["rope"].shape), (2, 1, 64))
+        self.assertEqual(captured["rope"].dtype, torch.bfloat16)
+        self.assertTrue(torch.all(captured["rope"] == 0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add a guarded compatibility path for GLM-5.3 native NoPE sparse MLA on NVIDIA SM120/SM121 using the existing FlashInfer SM120 sparse-MLA kernel.

This is the cleaned-up PR form of the field-tested workaround documented in #21. It is rebased directly onto `guqiong96/Lsglang:main@27df27cb7`, after the GLM-5.3 support base was merged.

Depends on #20 for ModelOpt glob exclusion matching. The two #20 files are intentionally excluded from this PR.

## Changes

- accept `Glm5NextForConditionalGeneration` and its NextN architecture for the guarded SM12x FP8 sparse-MLA path;
- reserve the existing 656-byte packed FP8 KV layout and write a zero 64-wide BF16 RoPE tail for native NoPE KV;
- zero-pad absorbed GLM queries from 512 to the compiled kernel's 576-wide interface and expose a numerically inert 64-wide RoPE tail;
- preserve active sparse lengths, handle empty rows, initialize padding to `-1`, and clamp kpool history to the compiled 2048-entry capacity;
- keep PDL disabled for this compatibility call;
- preserve ModelOpt FP4 for the GLM NextN block while retaining the existing DeepSeek behavior;
- add focused CPU unit tests for API mapping, backend gating, packed NoPE KV, kpool bounds, and GLM NextN weight loading.

## Validation

PR branch:

- `git apply --check` against current `main`: clean;
- `py_compile`: passed for all 9 changed Python files;
- `test_flashinfer_sparse_mla.py`: 8/8 passed;
- `test_glm5_next_nextn_weight_loading.py`: 2/2 passed;
- `git diff --check`: passed;
- diff audit: 9 source/test files only, no runtime scripts, machine paths, credentials, or deployment configuration.

Field validation of the same compatibility patch on RTX PRO 5000 72GB (SM120), CUDA 13, FlashInfer 0.6.17, single-GPU CPU/GPU mixed MoE:

- target and quantized NextN weights load;
- FP8 target and draft KV allocate;
- fixed EAGLE MTP and decode CUDA graphs capture and replay;
- OpenAI-compatible chat, tool, and Responses paths return valid structured output;
- 32K input / 2K output cold-prefix baseline: PP 764.21 tok/s, engine PP 870.85 tok/s, pure TG 40.78 tok/s;
- 261,112 input / 1,024 output completed on a 0.94 boundary profile: PP 953.20 tok/s, engine PP 969.69 tok/s, pure TG 41.62 tok/s.

## Scope and limitations

- SM120/SM121 + FP8 KV + GLM-5.3 NoPE only;
- reuses the DeepSeek-shaped kernel interface and pays the zero-padding KV storage cost;
- not a replacement for a native GLM NoPE SM120 sparse-MLA kernel;
- PDL remains disabled in this compatibility call;
- #20 must land first (or be applied together) for the validated NVFP4 checkpoint's wildcard exclusion list.

## Follow-up work

- restore and benchmark native Indexer/TopK/mHC kernels individually after SM120 support is correct;
- evaluate the upstream GLM-5.3 DFlash2 hidden-state capture path separately;
- replace this adapter when a native NoPE SM120 sparse-MLA kernel is available.

Refs #21.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #33150561837](https://github.com/guqiong96/Lsglang/actions/runs/33150561837)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #33150560945](https://github.com/guqiong96/Lsglang/actions/runs/33150560945)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:warning: [Run #33150562026](https://github.com/guqiong96/Lsglang/actions/runs/33150562026)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->