### PR TITLE
[Feature] Add optional NVMe-backed Engram lookup for DeepSeek-V4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Open GPU Prefill, `max_num_batched_tokens=8192` (row 1) / `32768` (row 2):
 | deepseek-ai/DeepSeek-V4-Flash-0731 | Lsglang-v1.4.7 | EPYC 9684x *2 | 24ch ddr5 4800 | pro 6000 * 1 | 4600 t/s [in 131072] | 75 t/s [in 131072] | 100~132 t/s |
 | deepseek-ai/DeepSeek-V4.1-Flash | Lsglang-v1.5.3 | EPYC 9V74 *2 | ddr5 576g | 4080S * 2 | — | — | 60 t/s |
 
+Experimental DeepSeek-V4.1 storage option: [exact NVMe Engram lookup](examples/runtime/deepseek_v4/README.engram_nvme.md).
+
 ### Supported models & quant formats
 
 Most original MOE models verified on Lsglang (Qwen3/GLM/MiniMax series etc.):

--- a/README_cn.md
+++ b/README_cn.md
@@ -107,6 +107,8 @@ lk_moe 集成被整理为 [`patches/`](./patches) 下的可移植补丁：
 | deepseek-ai/DeepSeek-V4-Flash-0731 | Lsglang-v1.4.7 | EPYC 9684x *2 | 24ch ddr5 4800 | pro 6000 * 1 | 4600 t/s [输入 131072] | 75 t/s [输入 131072] | 100~132 t/s |
 | deepseek-ai/DeepSeek-V4.1-Flash | Lsglang-v1.5.3 | EPYC 9V74 *2 | ddr5 576g | 4080S * 2 | — | — | 60 t/s |
 
+实验性 DeepSeek-V4.1 存储选项：[精确 NVMe Engram 读取](examples/runtime/deepseek_v4/README.engram_nvme.md)。
+
 ### 支持的模型与量化格式
 
 Lsglang 已验证的大部分原版 MOE 模型（Qwen3/GLM/MiniMax 等系列）：

--- a/examples/runtime/deepseek_v4/README.engram_nvme.md
+++ b/examples/runtime/deepseek_v4/README.engram_nvme.md
@@ -1,0 +1,114 @@
+# Exact NVMe Engram lookup (experimental)
+
+DeepSeek-V4.1 Engram tables can exceed available host memory. This opt-in backend
+keeps the original FP8 rows and E8M0 scales in a local safetensors shard and reads
+only the rows needed by each forward. Hashing, gating, projections and the
+existing `engram_gather` dequantization kernel are unchanged.
+
+This feature does **not** offload inference-time MoE experts to NVMe. CPU expert
+weights, checkpoint loading temporaries, KV cache and the rest of the model must
+still fit. It does not change NUMA allocation policy or tune FP8 kernels.
+
+## Requirements and supported scope
+
+- Linux, CUDA, a C++17 compiler and Ninja. The small host-only reader is built
+  from packaged source through `torch.utils.cpp_extension.load` at initialization.
+  No external `libaio` package or CUDA compiler is needed for this reader.
+- A local, indexed safetensors checkpoint on a filesystem supporting `O_DIRECT`
+  and Linux native AIO. Regular NVMe storage is intended; network filesystems
+  and other direct-I/O layouts have not been validated.
+- 256-wide `F8_E4M3` weight rows with eight `F8_E8M0` scales per row. A layer's
+  weight and scale must be in the same shard. The backing files must remain
+  present and immutable for the worker's lifetime.
+- One worker (`TP=PP=1`, world size 1), one running request, overlap scheduling
+  disabled, no speculative decoding and no `torch.compile`. Unsupported
+  configurations fail at initialization. The existing host-table option is
+  mutually exclusive with NVMe mode.
+- CUDA graph staging must be warmed on the capture stream. Decode graph BS=1
+  and eager Prefill are the tested configuration. Concurrent graph replay on
+  multiple streams is unsupported.
+
+## Enable
+
+Start from a working DeepSeek-V4.1 model configuration with sufficient memory
+for its non-Engram weights. Add the following environment settings and flags:
+
+```bash
+export SGLANG_ENABLE_DSV41_ENGRAM_NVME=1
+export SGLANG_ENABLE_DSV41_ENGRAM_HOST_TABLE=0
+# Each limit is PER ENGRAM LAYER, not per model.
+export SGLANG_DSV41_ENGRAM_NVME_CACHE_BYTES=1073741824
+export SGLANG_DSV41_ENGRAM_NVME_STAGING_BYTES=134217728
+
+python -m sglang.launch_server \
+  --model-path "$MODEL_PATH" \
+  --tensor-parallel-size 1 \
+  --max-running-requests 1 --disable-overlap-schedule \
+  --chunked-prefill-size 2048 \
+  --context-length 32768 --max-total-tokens 32768 \
+  --cuda-graph-backend-prefill disabled \
+  --cuda-graph-backend-decode full \
+  --cuda-graph-max-bs-decode 1 --cuda-graph-bs-decode 1
+```
+
+`MODEL_PATH` must be a downloaded checkpoint directory, not a Hub model ID.
+Retain the appropriate MoE runner, CPU/GPU placement, memory fraction and other
+flags from the working configuration. This example is not a promise that the
+entire model fits on a particular GPU or a 256GiB host.
+
+NVMe mode defaults to off. Cache bytes may be zero to disable the row cache;
+negative budgets are rejected. Staging includes pinned IDs/rows/scales and
+device row/scale/sequential-index buffers, allocated lazily by stream and
+power-of-two capacity. Its limit must be positive. Output activations and
+framework allocations are not included in that staging limit. Each store also
+has a fixed 512KiB I/O page buffer and at most 4096 callback descriptors.
+The default cache is 1GiB per layer, approximately 2GiB for the two V4.1 tables.
+
+## Execution and lifetime
+
+For a miss, the reader deduplicates the required aligned 4KiB pages in batches
+of at most 32 rows / 128 pages. Native AIO submits the page reads and waits for
+all completions before publishing exact bytes to pinned staging. The native
+CUDA host callback makes no CUDA API calls. The CUDA stream then copies the
+rows to the GPU and invokes the existing gather kernel.
+
+Initialization failures report an error. A missing row, truncated backing file
+or I/O failure during a callback aborts the worker rather than allowing a
+generation to consume stale or missing bytes. The checkpoint is immutable:
+model-level weight reload is rejected before consuming new weights once the
+initial load has completed.
+
+Eager stores can be closed explicitly; cleanup waits for pending CUDA work.
+Captured graphs keep raw host pointers and can outlive Python model references,
+so a captured store and its staging are owned by the worker until process exit.
+Closing a captured store is rejected. Restart the worker to release captured
+storage or replace the checkpoint. This deliberate lifetime policy does not
+support model hot-swapping in one worker.
+
+Optional scale residency, service health polling, trigger files, machine-specific
+NUMA workarounds and FP4 checkpoint-load staging are not part of this backend.
+
+## Tests
+
+Use a direct-I/O-capable temporary directory. These tests generate small fixture
+files; no model checkpoint is required.
+
+```bash
+export PYTHONPATH=python
+export TMPDIR=/path/to/nvme/test-tmp
+mkdir -p "$TMPDIR"
+python test/registered/unit/test_engram_nvme.py -v
+python test/manual/test_engram_nvme_cuda.py -v
+```
+
+The CPU tests check checkpoint metadata, exact bytes, empty and multi-batch
+requests, cache collisions, ownership ranges, concurrent native calls, cache
+accounting, invalid IDs, short files and unsupported configuration guards.
+The CUDA tests check eager lookup, the actual `EngramEmbedding` integration,
+unchanged default allocation, pending-callback cleanup, staging limits, reload
+rejection, and 24 graph replays after dropping the caller's storage reference.
+
+The backend was extracted from a field adapter tested on SM120. Field timings
+of 15.97 to 29.62 tokens/s at 16K input / 2K output included additional scale
+and NUMA changes, and are not benchmarks of this isolated PR. Full-model
+throughput and model-quality evaluation of this branch remain pending.

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1406,6 +1406,11 @@ class Envs:
     # Keep the DeepSeek-V4.1 engram tables in host memory (layout below) and gather
     # rows from the GPU instead of sharding them over HBM.
     SGLANG_ENABLE_DSV41_ENGRAM_HOST_TABLE = EnvBool(False)
+    # Exact, bounded-memory lookup from an immutable local safetensors shard.
+    # Cache and staging limits are per Engram layer, in bytes.
+    SGLANG_ENABLE_DSV41_ENGRAM_NVME = EnvBool(False)
+    SGLANG_DSV41_ENGRAM_NVME_CACHE_BYTES = EnvInt(1 << 30)
+    SGLANG_DSV41_ENGRAM_NVME_STAGING_BYTES = EnvInt(128 << 20)
     # Overlap layer 14's shared-host lookup and WKV with earlier layers at BS=1.
     SGLANG_ENABLE_DSV41_ENGRAM_KV_PREFETCH = EnvBool(False)
     # Diagnostic: disable the decode-only side streams (early compress/indexer

--- a/python/sglang/srt/layers/engram.py
+++ b/python/sglang/srt/layers/engram.py
@@ -686,7 +686,36 @@ class EngramEmbedding(nn.Module):
         row_end = num_embeddings * (tp_rank + 1) // self.tp_size
         self.rows = row_end - self.row_start
         self.host_table: Optional[_HostTable] = None
-        if envs.SGLANG_ENABLE_DSV41_ENGRAM_HOST_TABLE.get():
+        self.nvme_table = None
+        if envs.SGLANG_ENABLE_DSV41_ENGRAM_NVME.get():
+            from sglang.srt.layers.engram_nvme import (
+                NvmeEngramStore,
+                validate_configuration,
+            )
+            from sglang.srt.runtime_context import get_exec, get_schedule, get_spec
+
+            validate_configuration(
+                get_parallel(),
+                get_schedule(),
+                get_spec(),
+                get_exec().graph,
+                envs.SGLANG_ENABLE_DSV41_ENGRAM_HOST_TABLE.get(),
+            )
+            self.nvme_table = NvmeEngramStore(
+                get_model().model_path,
+                layer_id,
+                num_embeddings,
+                dim,
+                envs.SGLANG_DSV41_ENGRAM_NVME_CACHE_BYTES.get(),
+                envs.SGLANG_DSV41_ENGRAM_NVME_STAGING_BYTES.get(),
+            )
+            self.weight = nn.Parameter(
+                torch.empty(0, dtype=torch.float8_e4m3fn), requires_grad=False
+            )
+            self.scale = nn.Parameter(
+                torch.empty(0, dtype=torch.float8_e8m0fnu), requires_grad=False
+            )
+        elif envs.SGLANG_ENABLE_DSV41_ENGRAM_HOST_TABLE.get():
             self._init_host_table(num_embeddings, dim, layer_id)
         else:
             self.weight = nn.Parameter(
@@ -727,6 +756,11 @@ class EngramEmbedding(nn.Module):
         return self.host_table is not None and self.host_table.layout == "shared"
 
     def _load_rows(self, param: nn.Parameter, loaded_weight: torch.Tensor):
+        if self.nvme_table is not None:
+            self.nvme_table.validate_weight(
+                "weight" if param is self.weight else "scale", loaded_weight
+            )
+            return
         rows = slice(self.row_start, self.row_start + self.rows)
         if self._shared:
             param.data[rows].copy_(loaded_weight[rows])
@@ -738,6 +772,8 @@ class EngramEmbedding(nn.Module):
     def finish_load(self, label: str = ""):
         """Barrier (shared layout) once every rank has written its rows; log how
         the table ended up backed."""
+        if self.nvme_table is not None:
+            self.nvme_table.finish_load()
         if self.host_table is not None:
             self.host_table.finish_load(label)
 
@@ -793,6 +829,8 @@ class EngramEmbedding(nn.Module):
 
     def _owned_rows(self, indices: torch.Tensor) -> torch.Tensor:
         """Rows of `indices` this rank's shard holds, zero for the rest."""
+        if self.nvme_table is not None:
+            return self.nvme_table.lookup(indices)
         if self.rows == 0:
             return self._empty(indices).zero_()
         if self.host_table is None and (

--- a/python/sglang/srt/layers/engram_nvme.cpp
+++ b/python/sglang/srt/layers/engram_nvme.cpp
@@ -1,0 +1,265 @@
+// Exact immutable FP8 row retrieval; bounded direct-mapped RAM cache.
+// No CUDA calls in the callback: suitable for cudaLaunchHostFunc graph nodes.
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <linux/aio_abi.h>
+#include <mutex>
+#include <new>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+struct Store {
+  int fd;
+  aio_context_t aio = 0;
+  uint8_t *pages = nullptr;
+  std::mutex batch_lock;
+  std::atomic<uint64_t> batches{0}, peak_pages{0};
+  uint64_t rows, weight_offset, scale_offset, slots, row_lo, row_hi;
+  uint8_t *cache;
+  uint64_t *keys;
+  std::atomic<uint64_t> hits{0}, misses{0}, reads{0};
+};
+struct Work {
+  Store *store;
+  const int64_t *ids;
+  uint8_t *weights, *scales;
+  uint64_t count;
+};
+
+static void fail(const char *reason) {
+  std::fprintf(stderr, "Engram retrieval failed: %s (errno=%d)\n", reason,
+               errno);
+  std::abort(); // Never allow a generation to continue with missing/stale rows.
+}
+
+extern "C" void row_store_close(Store *s);
+
+extern "C" Store *row_store_open(const char *path, uint64_t rows, uint64_t woff,
+                                 uint64_t soff, uint64_t budget) {
+  auto *s = new (std::nothrow) Store{};
+  if (!s) {
+    errno = ENOMEM;
+    return nullptr;
+  }
+  s->fd = open(path, O_RDONLY | O_CLOEXEC | O_DIRECT);
+  if (s->fd < 0) {
+    delete s;
+    return nullptr;
+  }
+  struct stat statbuf;
+  if (fstat(s->fd, &statbuf) || !S_ISREG(statbuf.st_mode) ||
+      rows > uint64_t(INT64_MAX) || woff > uint64_t(statbuf.st_size) ||
+      soff > uint64_t(statbuf.st_size) ||
+      rows > (uint64_t(statbuf.st_size) - woff) / 256 ||
+      rows > (uint64_t(statbuf.st_size) - soff) / 8) {
+    row_store_close(s);
+    errno = EINVAL;
+    return nullptr;
+  }
+  s->rows = rows;
+  s->weight_offset = woff;
+  s->scale_offset = soff;
+  s->row_lo = 0;
+  s->row_hi = rows;
+  s->slots = budget / 272;
+  if (s->slots) {
+    s->cache = static_cast<uint8_t *>(mmap(nullptr, s->slots * 264,
+                                           PROT_READ | PROT_WRITE,
+                                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    s->keys = static_cast<uint64_t *>(mmap(nullptr, s->slots * sizeof(uint64_t),
+                                           PROT_READ | PROT_WRITE,
+                                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    if (s->cache == MAP_FAILED || s->keys == MAP_FAILED) {
+      int error = errno;
+      row_store_close(s);
+      errno = error;
+      return nullptr;
+    }
+  }
+  int error =
+      posix_memalign(reinterpret_cast<void **>(&s->pages), 4096, 128 * 4096);
+  if (error) {
+    row_store_close(s);
+    errno = error;
+    return nullptr;
+  }
+  if (syscall(SYS_io_setup, 128, &s->aio) < 0) {
+    error = errno;
+    row_store_close(s);
+    errno = error;
+    return nullptr;
+  }
+  return s;
+}
+
+// At most 32 misses and 128 unique pages per batch, including boundary
+// crossings.
+struct ReadBatch {
+  std::array<uint64_t, 128> offsets{};
+  std::array<size_t, 128> required{};
+  size_t count = 0;
+  void add(uint64_t offset, size_t length) {
+    while (length) {
+      uint64_t base = offset & ~uint64_t(4095);
+      size_t delta = offset - base, take = std::min(length, 4096 - delta);
+      size_t j = 0;
+      while (j < count && offsets[j] != base)
+        ++j;
+      if (j == count) {
+        if (count == offsets.size())
+          fail("batch page limit");
+        offsets[count++] = base;
+      }
+      required[j] = std::max(required[j], delta + take);
+      offset += take;
+      length -= take;
+    }
+  }
+  void read(Store *s) {
+    if (!count)
+      return;
+    std::array<iocb, 128> requests{};
+    std::array<iocb *, 128> pointers{};
+    for (size_t j = 0; j < count; ++j) {
+      auto &request = requests[j];
+      request.aio_data = j;
+      request.aio_lio_opcode = IOCB_CMD_PREAD;
+      request.aio_fildes = s->fd;
+      request.aio_buf = reinterpret_cast<uint64_t>(s->pages + j * 4096);
+      request.aio_nbytes = 4096;
+      request.aio_offset = offsets[j];
+      pointers[j] = &request;
+    }
+    size_t submitted = 0;
+    while (submitted < count) {
+      long queued;
+      do {
+        queued = syscall(SYS_io_submit, s->aio, count - submitted,
+                         pointers.data() + submitted);
+      } while (queued < 0 && errno == EINTR);
+      if (queued <= 0)
+        fail("io_submit");
+      std::array<io_event, 128> events{};
+      long completed = 0;
+      while (completed < queued) {
+        long got;
+        do {
+          got = syscall(SYS_io_getevents, s->aio, 1, queued - completed,
+                        events.data(), nullptr);
+        } while (got < 0 && errno == EINTR);
+        if (got <= 0)
+          fail("io_getevents");
+        for (long j = 0; j < got; ++j) {
+          const auto &event = events[j];
+          if (event.data < submitted || event.data >= submitted + queued ||
+              event.res < 0 || event.res2 != 0 ||
+              uint64_t(event.res) < required[event.data])
+            fail("short or failed asynchronous read");
+        }
+        completed += got;
+      }
+      submitted += queued;
+    }
+    s->reads.fetch_add(count, std::memory_order_relaxed);
+    ++s->batches;
+    if (count > s->peak_pages.load())
+      s->peak_pages.store(count);
+  }
+  void copy(Store *s, uint64_t offset, uint8_t *out, size_t length) const {
+    while (length) {
+      uint64_t base = offset & ~uint64_t(4095);
+      size_t delta = offset - base, take = std::min(length, 4096 - delta);
+      size_t j = 0;
+      while (j < count && offsets[j] != base)
+        ++j;
+      if (j == count)
+        fail("missing batch page");
+      std::memcpy(out, s->pages + j * 4096 + delta, take);
+      offset += take;
+      out += take;
+      length -= take;
+    }
+  }
+};
+
+extern "C" void row_store_lookup(void *opaque) {
+  auto *work = static_cast<Work *>(opaque);
+  Store *s = work->store;
+  // One callback owns the bounded I/O buffers and cache until every read
+  // completes.
+  std::lock_guard<std::mutex> guard(s->batch_lock);
+  for (uint64_t begin = 0; begin < work->count; begin += 32) {
+    ReadBatch batch;
+    std::array<uint64_t, 32> misses{};
+    size_t miss_count = 0;
+    uint64_t end = begin + std::min(uint64_t(32), work->count - begin);
+    for (uint64_t i = begin; i < end; ++i) {
+      int64_t id = work->ids[i];
+      if (id < 0 || uint64_t(id) >= s->rows)
+        fail("row ID out of bounds");
+      if (uint64_t(id) < s->row_lo || uint64_t(id) >= s->row_hi) {
+        std::memset(work->weights + i * 256, 0, 256);
+        std::memset(work->scales + i * 8, 0, 8);
+        continue;
+      }
+      uint64_t slot = s->slots ? uint64_t(id) % s->slots : 0;
+      if (s->slots && s->keys[slot] == uint64_t(id) + 1) {
+        std::memcpy(work->weights + i * 256, s->cache + slot * 264, 256);
+        std::memcpy(work->scales + i * 8, s->cache + slot * 264 + 256, 8);
+        ++s->hits;
+      } else {
+        misses[miss_count++] = i;
+        batch.add(s->weight_offset + uint64_t(id) * 256, 256);
+        batch.add(s->scale_offset + uint64_t(id) * 8, 8);
+        ++s->misses;
+      }
+    }
+    batch.read(s);
+    for (size_t j = 0; j < miss_count; ++j) {
+      uint64_t i = misses[j], id = work->ids[i];
+      uint8_t row[264];
+      batch.copy(s, s->weight_offset + id * 256, row, 256);
+      batch.copy(s, s->scale_offset + id * 8, row + 256, 8);
+      std::memcpy(work->weights + i * 256, row, 256);
+      std::memcpy(work->scales + i * 8, row + 256, 8);
+      if (s->slots) {
+        uint64_t slot = id % s->slots;
+        std::memcpy(s->cache + slot * 264, row, 264);
+        s->keys[slot] = id + 1;
+      }
+    }
+  }
+}
+
+extern "C" void row_store_stats(Store *s, uint64_t *out) {
+  out[0] = s->hits.load();
+  out[1] = s->misses.load();
+  out[2] = s->reads.load();
+  out[3] = s->slots * 272;
+}
+extern "C" void row_store_range(Store *s, uint64_t lo, uint64_t hi) {
+  if (lo > hi || hi > s->rows)
+    fail("invalid row ownership range");
+  s->row_lo = lo;
+  s->row_hi = hi;
+}
+extern "C" void row_store_close(Store *s) {
+  if (s->cache && s->cache != MAP_FAILED)
+    munmap(s->cache, s->slots * 264);
+  if (s->keys && s->keys != MAP_FAILED)
+    munmap(s->keys, s->slots * sizeof(uint64_t));
+  if (s->aio && syscall(SYS_io_destroy, s->aio) < 0)
+    fail("io_destroy");
+  std::free(s->pages);
+  close(s->fd);
+  delete s;
+}

--- a/python/sglang/srt/layers/engram_nvme.py
+++ b/python/sglang/srt/layers/engram_nvme.py
@@ -1,0 +1,296 @@
+"""Opt-in exact NVMe Engram lookup for single-worker CUDA inference.
+
+The checkpoint must remain immutable for the worker's lifetime. Captured CUDA
+graphs contain raw host pointers, so captured stores are retained until process
+exit. They cannot be closed or hot-reloaded independently of their graphs.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import functools
+import json
+import os
+import struct
+import sys
+import weakref
+from pathlib import Path
+
+import torch
+
+
+class _Work(ctypes.Structure):
+    _fields_ = [
+        ("store", ctypes.c_void_p),
+        ("ids", ctypes.c_void_p),
+        ("weights", ctypes.c_void_p),
+        ("scales", ctypes.c_void_p),
+        ("count", ctypes.c_uint64),
+    ]
+
+
+# CUDA graph replay bypasses Python; a Python finalizer alone cannot establish
+# that all graph references are gone. Process ownership makes that explicit.
+_CAPTURED_STORES: set[NvmeEngramStore] = set()
+
+
+def checkpoint_table(model_path, layer_id, rows, dim):
+    """Return validated local shard and offsets without materializing tensors."""
+    if dim != 256 or rows < 1:
+        raise ValueError("NVMe Engram requires nonempty 256-wide FP8 tables")
+    root = Path(model_path).resolve()
+    index_path = root / "model.safetensors.index.json"
+    if not index_path.is_file():
+        raise ValueError("NVMe Engram requires a local indexed safetensors checkpoint")
+    index = json.loads(index_path.read_text())["weight_map"]
+    prefix = f"layers.{layer_id}.engram.embed."
+    names = [prefix + "weight", prefix + "scale"]
+    if any(name not in index for name in names):
+        raise ValueError(f"Missing Engram checkpoint entries for layer {layer_id}")
+    if index[names[0]] != index[names[1]]:
+        raise ValueError("NVMe Engram weight and scale must share a checkpoint shard")
+    shard = (root / index[names[0]]).resolve()
+    if not shard.is_relative_to(root):
+        raise ValueError("Engram shard must be inside the checkpoint directory")
+    with shard.open("rb") as source:
+        size = os.fstat(source.fileno()).st_size
+        raw = source.read(8)
+        if len(raw) != 8:
+            raise ValueError("Truncated safetensors header")
+        length = struct.unpack("<Q", raw)[0]
+        if not 2 <= length <= min(100_000_000, size - 8):
+            raise ValueError("Invalid safetensors header length")
+        header = json.loads(source.read(length))
+    offsets = []
+    extents = []
+    for name, dtype, width in zip(names, ("F8_E4M3", "F8_E8M0"), (256, 8)):
+        tensor = header.get(name, {})
+        span = tensor.get("data_offsets", [])
+        if (
+            tensor.get("dtype") != dtype
+            or tensor.get("shape") != [rows, width]
+            or len(span) != 2
+            or any(type(value) is not int for value in span)
+            or not 0 <= span[0] <= span[1] <= size - 8 - length
+            or span[1] - span[0] != rows * width
+        ):
+            raise ValueError(f"Invalid Engram tensor metadata: {name}")
+        extents.append(span)
+        offsets.append(8 + length + span[0])
+    if max(x[0] for x in extents) < min(x[1] for x in extents):
+        raise ValueError("Overlapping Engram weight and scale extents")
+    return shard, offsets
+
+
+def validate_configuration(parallel, schedule, spec, graph, host_table):
+    if sys.platform != "linux" or torch.version.cuda is None:
+        raise ValueError("NVMe Engram requires Linux and CUDA")
+    if any(
+        getattr(parallel, field) != 1 for field in ("tp_size", "pp_size", "world_size")
+    ):
+        raise ValueError("NVMe Engram currently supports a single worker (TP=PP=1)")
+    if schedule.max_running_requests != 1 or not schedule.disable_overlap_schedule:
+        raise ValueError(
+            "NVMe Engram requires --max-running-requests 1 --disable-overlap-schedule"
+        )
+    if spec.speculative_algorithm or graph.enable_torch_compile:
+        raise ValueError(
+            "NVMe Engram does not yet support speculation or torch.compile"
+        )
+    if host_table:
+        raise ValueError("NVMe Engram and host-table mode are mutually exclusive")
+
+
+@functools.lru_cache(maxsize=1)
+def _native_library():
+    from torch.utils.cpp_extension import load
+
+    path = load(
+        name="sglang_engram_nvme",
+        sources=[str(Path(__file__).with_suffix(".cpp"))],
+        extra_cflags=["-O3", "-std=c++17", "-pthread"],
+        extra_ldflags=["-pthread"],
+        with_cuda=False,
+        is_python_module=False,
+    )
+    lib = ctypes.CDLL(path, use_errno=True)
+    lib.row_store_open.argtypes = [ctypes.c_char_p] + [ctypes.c_uint64] * 4
+    lib.row_store_open.restype = ctypes.c_void_p
+    lib.row_store_close.argtypes = [ctypes.c_void_p]
+    lib.row_store_close.restype = None
+    lib.row_store_lookup.argtypes = [ctypes.c_void_p]
+    lib.row_store_lookup.restype = None
+    lib.row_store_stats.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64)]
+    lib.row_store_stats.restype = None
+    return lib
+
+
+@functools.lru_cache(maxsize=1)
+def _cuda_library():
+    # Use the runtime already loaded by torch, rather than guessing wheel paths
+    # and potentially loading a different CUDA runtime into the process.
+    paths = {
+        line.split()[-1]
+        for line in Path("/proc/self/maps").read_text().splitlines()
+        if "/libcudart.so" in line and line.split()[-1].startswith("/")
+    }
+    if len(paths) != 1:
+        raise RuntimeError(f"Expected one loaded CUDA runtime; found {len(paths)}")
+    lib = ctypes.CDLL(paths.pop())
+    lib.cudaLaunchHostFunc.argtypes = [ctypes.c_void_p] * 3
+    lib.cudaLaunchHostFunc.restype = ctypes.c_int
+    return lib
+
+
+def _release(lib, store, staging, works, device):
+    if staging:
+        with torch.cuda.device(device):
+            torch.cuda.synchronize()
+    lib.row_store_close(store)
+    staging.clear()
+    works.clear()
+
+
+class NvmeEngramStore:
+    def __init__(self, model_path, layer_id, rows, dim, cache_bytes, staging_bytes):
+        if type(cache_bytes) is not int or not 0 <= cache_bytes < 2**63:
+            raise ValueError("NVMe Engram cache bytes must be a nonnegative int64")
+        if type(staging_bytes) is not int or not 0 < staging_bytes < 2**63:
+            raise ValueError("NVMe Engram staging bytes must be a positive int64")
+        shard, offsets = checkpoint_table(model_path, layer_id, rows, dim)
+        self.rows = rows
+        self._loaded = set()
+        self._staging = {}
+        self._works = {}
+        self._staging_bytes = 0
+        self._staging_limit = staging_bytes
+        self._device = torch.cuda.current_device()
+        self._lib = _native_library()
+        self._cuda = _cuda_library()
+        self._store = self._lib.row_store_open(
+            os.fsencode(shard), rows, *offsets, cache_bytes
+        )
+        if not self._store:
+            error = ctypes.get_errno()
+            raise OSError(
+                error,
+                f"Cannot open NVMe Engram shard: {os.strerror(error)}",
+                str(shard),
+            )
+        self._finalizer = weakref.finalize(
+            self,
+            _release,
+            self._lib,
+            self._store,
+            self._staging,
+            self._works,
+            self._device,
+        )
+        # CUDA may already be torn down during interpreter exit. The OS reclaims
+        # process-owned mappings and descriptors, including captured stores.
+        self._finalizer.atexit = False
+
+    def validate_weight(self, kind, source):
+        if kind in self._loaded:
+            raise RuntimeError(
+                "NVMe Engram checkpoints are immutable; restart to reload"
+            )
+        width, dtype = (
+            (256, torch.float8_e4m3fn)
+            if kind == "weight"
+            else (8, torch.float8_e8m0fnu)
+        )
+        if list(source.shape) != [self.rows, width] or source.dtype != dtype:
+            raise ValueError(f"Engram {kind} checkpoint shape/dtype mismatch")
+        self._loaded.add(kind)
+
+    def close(self):
+        if self in _CAPTURED_STORES:
+            raise RuntimeError(
+                "Captured NVMe Engram storage is owned by the worker until exit"
+            )
+        self._finalizer()
+        self._works.clear()
+
+    def finish_load(self):
+        if self._loaded != {"weight", "scale"}:
+            raise ValueError(
+                "NVMe Engram checkpoint did not load both weight and scale"
+            )
+
+    def stats(self):
+        if not self._finalizer.alive:
+            raise RuntimeError("NVMe Engram store is closed")
+        values = (ctypes.c_uint64 * 4)()
+        self._lib.row_store_stats(self._store, values)
+        return dict(zip(("hits", "misses", "read_pages", "cache_bytes"), values))
+
+    def lookup(self, indices):
+        from sglang.kernels.ops.embeddings.engram_gather import engram_gather
+
+        if not self._finalizer.alive:
+            raise RuntimeError("NVMe Engram store is closed")
+        if (
+            not indices.is_cuda
+            or indices.device.index != self._device
+            or indices.dtype != torch.int64
+        ):
+            raise ValueError("Engram IDs must be int64 on the store's CUDA device")
+        count = indices.numel()
+        out = torch.empty(
+            (*indices.shape, 256), dtype=torch.bfloat16, device=indices.device
+        )
+        if not count:
+            return out
+        capacity = 1 << (count - 1).bit_length()
+        stream = torch.cuda.current_stream(self._device)
+        key = (stream.cuda_stream, capacity)
+        capturing = torch.cuda.is_current_stream_capturing()
+        if key not in self._staging:
+            if capturing:
+                raise RuntimeError(
+                    "Warm NVMe Engram staging on the capture stream before capture"
+                )
+            size = capacity * (8 + 256 + 8 + 256 + 8 + 8)
+            if self._staging_bytes + size > self._staging_limit:
+                raise RuntimeError(
+                    "NVMe Engram staging budget exceeded; reduce prefill chunk size or increase SGLANG_DSV41_ENGRAM_NVME_STAGING_BYTES"
+                )
+            ids = torch.empty(capacity, dtype=torch.int64, pin_memory=True)
+            w = torch.empty((capacity, 256), dtype=torch.uint8, pin_memory=True)
+            s = torch.empty((capacity, 8), dtype=torch.uint8, pin_memory=True)
+            dw, ds = (
+                torch.empty_like(w, device=indices.device),
+                torch.empty_like(s, device=indices.device),
+            )
+            sequential = torch.arange(
+                capacity, dtype=torch.int64, device=indices.device
+            )
+            self._staging[key] = ids, w, s, dw, ds, sequential
+            self._staging_bytes += size
+        ids, w, s, dw, ds, sequential = self._staging[key]
+        work_key = (stream.cuda_stream, count)
+        if work_key not in self._works:
+            if len(self._works) >= 4096:
+                raise RuntimeError(
+                    "NVMe Engram work metadata budget exceeded; restart the worker"
+                )
+            self._works[work_key] = _Work(
+                self._store, ids.data_ptr(), w.data_ptr(), s.data_ptr(), count
+            )
+        if capturing:
+            _CAPTURED_STORES.add(self)
+        ids[:count].copy_(indices.reshape(-1), non_blocking=True)
+        error = self._cuda.cudaLaunchHostFunc(
+            stream.cuda_stream,
+            ctypes.cast(self._lib.row_store_lookup, ctypes.c_void_p),
+            ctypes.addressof(self._works[work_key]),
+        )
+        if error:
+            raise RuntimeError(f"CUDA Engram host callback failed: {error}")
+        dw[:count].copy_(w[:count], non_blocking=True)
+        ds[:count].copy_(s[:count], non_blocking=True)
+        engram_gather(
+            dw.data_ptr(), ds.data_ptr(), sequential[:count], out.view(-1, 256), 256, 32
+        )
+        return out

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -4222,6 +4222,7 @@ class DeepseekV4ForCausalLM(nn.Module):
         # mid-serving (RL refit sends many partial batches); the prewarm and
         # its barrier must only run on the first (startup) load.
         self._mhc_prewarmed_at_load = False
+        self._nvme_engram_loaded = False
 
     @property
     def routed_experts_weights_of_layer(self):
@@ -4801,6 +4802,10 @@ class DeepseekV4ForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]], is_nextn=False):
+        if self._nvme_engram_loaded:
+            raise RuntimeError(
+                "NVMe Engram checkpoints are immutable; restart to reload"
+            )
         params_dict = dict(self.named_parameters())
         loaded_params: Set[str] = set()
 
@@ -5193,6 +5198,7 @@ class DeepseekV4ForCausalLM(nn.Module):
             for i, layer in enumerate(self.model.layers):
                 if getattr(layer, "engram", None) is not None:
                     layer.engram.embed.finish_load(label=f"layer {i}")
+            self._nvme_engram_loaded = envs.SGLANG_ENABLE_DSV41_ENGRAM_NVME.get()
             self._prewarm_mhc_kernels()
 
     def get_embed_and_head(self):

--- a/test/manual/test_engram_nvme_cuda.py
+++ b/test/manual/test_engram_nvme_cuda.py
@@ -1,0 +1,193 @@
+"""Small CUDA integration test, no model checkpoint required.
+
+Run explicitly on a Linux CUDA host with a direct-I/O-capable temp directory:
+TMPDIR=/nvme/tmp PYTHONPATH=python python test/manual/test_engram_nvme_cuda.py -v
+"""
+
+import gc
+import json
+import struct
+import tempfile
+import unittest
+import weakref
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.engram_nvme import NvmeEngramStore
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+class TestNvmeCuda(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.w = (torch.arange(257 * 256).remainder(112).to(torch.uint8)).view(257, 256)
+        self.s = (torch.arange(257 * 8).remainder(3) + 126).to(torch.uint8).view(257, 8)
+        header = {
+            "layers.1.engram.embed.weight": {
+                "dtype": "F8_E4M3",
+                "shape": [257, 256],
+                "data_offsets": [0, self.w.numel()],
+            },
+            "layers.1.engram.embed.scale": {
+                "dtype": "F8_E8M0",
+                "shape": [257, 8],
+                "data_offsets": [self.w.numel(), self.w.numel() + self.s.numel()],
+            },
+        }
+        raw = json.dumps(header).encode()
+        (self.root / "table.safetensors").write_bytes(
+            struct.pack("<Q", len(raw))
+            + raw
+            + self.w.numpy().tobytes()
+            + self.s.numpy().tobytes()
+        )
+        (self.root / "model.safetensors.index.json").write_text(
+            json.dumps({"weight_map": {key: "table.safetensors" for key in header}})
+        )
+
+    def tearDown(self):
+        torch.cuda.synchronize()
+        self.tmp.cleanup()
+
+    def store(self, staging_bytes=8 << 20):
+        return NvmeEngramStore(self.root, 1, 257, 256, 17 * 272, staging_bytes)
+
+    def expected(self, ids):
+        weights = (
+            self.w[ids.cpu()]
+            .view(torch.float8_e4m3fn)
+            .float()
+            .reshape(*ids.shape, 8, 32)
+        )
+        scales = torch.pow(2.0, self.s[ids.cpu()].float() - 127)
+        return (weights * scales.unsqueeze(-1)).flatten(-2).to(torch.bfloat16)
+
+    def test_eager_empty_cache_and_close(self):
+        store = self.store()
+        for count in (0, 1, 24, 33, 97, 2048):
+            ids = torch.arange(count, device="cuda", dtype=torch.int64).remainder(257)
+            torch.testing.assert_close(
+                store.lookup(ids).cpu(), self.expected(ids), rtol=0, atol=0
+            )
+        self.assertGreater(store.stats()["misses"], 0)
+        store.close()
+        store.close()
+        with self.assertRaises(RuntimeError):
+            store.lookup(torch.ones(1, device="cuda", dtype=torch.int64))
+
+    def test_eager_cleanup_with_pending_callback(self):
+        store = self.store()
+        ids = torch.arange(97, device="cuda", dtype=torch.int64)
+        out = store.lookup(ids)
+        ref = weakref.ref(store)
+        del store
+        gc.collect()
+        self.assertIsNone(ref())
+        torch.testing.assert_close(out.cpu(), self.expected(ids), rtol=0, atol=0)
+
+    def test_staging_and_input_guards(self):
+        store = self.store(staging_bytes=1)
+        with self.assertRaises(ValueError):
+            store.lookup(torch.ones(1, dtype=torch.int64))
+        with self.assertRaises(RuntimeError):
+            store.lookup(torch.ones(24, device="cuda", dtype=torch.int64))
+        store.close()
+
+    def test_graph_replay_retains_callback_owners(self):
+        store = self.store()
+        ids = torch.arange(48, device="cuda", dtype=torch.int64).view(2, 24)
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            for _ in range(3):
+                store.lookup(ids)
+        stream.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            out = store.lookup(ids)
+        with self.assertRaises(RuntimeError):
+            store.close()
+        ref = weakref.ref(store)
+        del store
+        gc.collect()
+        self.assertIsNotNone(ref())
+        for turn in range(24):
+            ids.copy_(
+                (
+                    torch.arange(48, device="cuda", dtype=torch.int64)
+                    * (turn + 1)
+                    % 257
+                ).view(2, 24)
+            )
+            graph.replay()
+            torch.testing.assert_close(out.cpu(), self.expected(ids), rtol=0, atol=0)
+
+    def test_embedding_integration_and_default_path(self):
+        from sglang.srt.environ import envs
+        from sglang.srt.layers import engram
+
+        parallel = SimpleNamespace(tp_size=1, tp_rank=0, pp_size=1, world_size=1)
+        schedule = SimpleNamespace(
+            max_running_requests=1, disable_overlap_schedule=True
+        )
+        with (
+            patch.object(engram, "get_parallel", return_value=parallel),
+            patch.object(
+                engram,
+                "get_model",
+                return_value=SimpleNamespace(model_path=str(self.root)),
+            ),
+            patch("sglang.srt.runtime_context.get_schedule", return_value=schedule),
+            patch(
+                "sglang.srt.runtime_context.get_spec",
+                return_value=SimpleNamespace(speculative_algorithm=None),
+            ),
+            patch(
+                "sglang.srt.runtime_context.get_exec",
+                return_value=SimpleNamespace(
+                    graph=SimpleNamespace(enable_torch_compile=False)
+                ),
+            ),
+            envs.SGLANG_ENABLE_DSV41_ENGRAM_NVME.override(True),
+            envs.SGLANG_ENABLE_DSV41_ENGRAM_HOST_TABLE.override(False),
+            envs.SGLANG_DSV41_ENGRAM_NVME_CACHE_BYTES.override(4096),
+        ):
+            embed = engram.EngramEmbedding(257, 256, 1)
+            with self.assertRaises(ValueError):
+                embed.finish_load()
+            embed._load_rows(embed.weight, self.w.view(torch.float8_e4m3fn))
+            embed._load_rows(embed.scale, self.s.view(torch.float8_e8m0fnu))
+            embed.finish_load()
+            self.assertEqual(embed.weight.numel(), 0)
+            self.assertEqual(embed.scale.numel(), 0)
+            ids = torch.arange(24, device="cuda", dtype=torch.int64)
+            torch.testing.assert_close(
+                embed(ids).cpu(), self.expected(ids), rtol=0, atol=0
+            )
+            with self.assertRaises(RuntimeError):
+                embed._load_rows(embed.weight, self.w.view(torch.float8_e4m3fn))
+            embed.nvme_table.close()
+            with envs.SGLANG_ENABLE_DSV41_ENGRAM_NVME.override(False):
+                original = engram.EngramEmbedding(257, 256, 1)
+                self.assertIsNone(original.nvme_table)
+                self.assertEqual(original.weight.shape, (257, 256))
+
+    def test_reload_rejected_before_consuming_weights(self):
+        from sglang.srt.models.deepseek_v4 import DeepseekV4ForCausalLM
+
+        def weights():
+            raise AssertionError("Reload must fail before touching checkpoint weights")
+            yield
+
+        with self.assertRaisesRegex(RuntimeError, "immutable"):
+            DeepseekV4ForCausalLM.load_weights(
+                SimpleNamespace(_nvme_engram_loaded=True), weights()
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_engram_nvme.py
+++ b/test/registered/unit/test_engram_nvme.py
@@ -1,0 +1,319 @@
+"""Exact storage tests; no model weights or GPU required."""
+
+import ctypes
+import json
+import os
+import random
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.layers.engram_nvme import (
+    _Work,
+    checkpoint_table,
+    validate_configuration,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+def fixture(root, rows=257, layer=1):
+    # Unaligned offsets exercise both row and scale page crossings. The final
+    # direct read extends past EOF but must contain every requested table byte.
+    weight = bytes((i * 7 + 11) % 256 for i in range(rows * 256))
+    scale = bytes((i * 3 + 19) % 256 for i in range(rows * 8))
+    prefix = f"layers.{layer}.engram.embed."
+    header = {
+        prefix + "weight": {
+            "dtype": "F8_E4M3",
+            "shape": [rows, 256],
+            "data_offsets": [4093, 4093 + len(weight)],
+        },
+        prefix + "scale": {
+            "dtype": "F8_E8M0",
+            "shape": [rows, 8],
+            "data_offsets": [4093 + len(weight), 4093 + len(weight) + len(scale)],
+        },
+    }
+    raw = json.dumps(header).encode()
+    shard = root / "table.safetensors"
+    shard.write_bytes(struct.pack("<Q", len(raw)) + raw + b"\0" * 4093 + weight + scale)
+    (root / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {name: shard.name for name in header}})
+    )
+    return shard, 8 + len(raw) + 4093, 8 + len(raw) + 4093 + len(weight), weight, scale
+
+
+class TestMetadata(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.shard, self.woff, self.soff, _, _ = fixture(self.root)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_exact_offsets(self):
+        self.assertEqual(
+            checkpoint_table(self.root, 1, 257, 256),
+            (self.shard, [self.woff, self.soff]),
+        )
+
+    def test_missing_or_unsupported_layout(self):
+        for layer, rows, dim in [
+            (2, 257, 256),
+            (1, 258, 256),
+            (1, 257, 128),
+            (1, 0, 256),
+        ]:
+            with (
+                self.subTest(layer=layer, rows=rows, dim=dim),
+                self.assertRaises(ValueError),
+            ):
+                checkpoint_table(self.root, layer, rows, dim)
+
+    def test_truncated_file(self):
+        self.shard.write_bytes(self.shard.read_bytes()[:-1])
+        with self.assertRaises(ValueError):
+            checkpoint_table(self.root, 1, 257, 256)
+
+    def test_invalid_header(self):
+        for data in [b"", struct.pack("<Q", 100_000_001)]:
+            self.shard.write_bytes(data)
+            with self.assertRaises(ValueError):
+                checkpoint_table(self.root, 1, 257, 256)
+
+    def test_invalid_tensor_metadata(self):
+        original = self.shard.read_bytes()
+        length = struct.unpack("<Q", original[:8])[0]
+        for key, value in [
+            ("dtype", "U8"),
+            ("data_offsets", [0, 3]),
+            ("data_offsets", [-1, 257 * 256 - 1]),
+            ("data_offsets", [0.0, 257 * 256.0]),
+        ]:
+            header = json.loads(original[8 : 8 + length])
+            header["layers.1.engram.embed.weight"][key] = value
+            raw = json.dumps(header).encode()
+            self.shard.write_bytes(
+                struct.pack("<Q", len(raw)) + raw + original[8 + length :]
+            )
+            with self.subTest(key=key, value=value), self.assertRaises(ValueError):
+                checkpoint_table(self.root, 1, 257, 256)
+
+    def test_shard_location_and_split(self):
+        index = self.root / "model.safetensors.index.json"
+        for weight, scale in [
+            ("table.safetensors", "other.safetensors"),
+            ("../outside", "../outside"),
+        ]:
+            index.write_text(
+                json.dumps(
+                    {
+                        "weight_map": {
+                            "layers.1.engram.embed.weight": weight,
+                            "layers.1.engram.embed.scale": scale,
+                        }
+                    }
+                )
+            )
+            with self.assertRaises(ValueError):
+                checkpoint_table(self.root, 1, 257, 256)
+
+    def test_configuration_guards(self):
+        parallel = SimpleNamespace(tp_size=1, pp_size=1, world_size=1)
+        schedule = SimpleNamespace(
+            max_running_requests=1, disable_overlap_schedule=True
+        )
+        spec = SimpleNamespace(speculative_algorithm=None)
+        graph = SimpleNamespace(enable_torch_compile=False)
+        with patch("torch.version.cuda", "13.0"):
+            validate_configuration(parallel, schedule, spec, graph, False)
+            for obj, key, value in [
+                (parallel, "world_size", 2),
+                (parallel, "tp_size", 2),
+                (schedule, "max_running_requests", 2),
+                (schedule, "disable_overlap_schedule", False),
+                (spec, "speculative_algorithm", "DSPARK"),
+                (graph, "enable_torch_compile", True),
+            ]:
+                with (
+                    self.subTest(key=key),
+                    patch.object(obj, key, value),
+                    self.assertRaises(ValueError),
+                ):
+                    validate_configuration(parallel, schedule, spec, graph, False)
+            with self.assertRaises(ValueError):
+                validate_configuration(parallel, schedule, spec, graph, True)
+
+
+class TestNativeReader(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.TemporaryDirectory()
+        cls.root = Path(cls.tmp.name)
+        cls.shard, cls.woff, cls.soff, cls.weights, cls.scales = fixture(cls.root)
+        source = (
+            Path(__file__).resolve().parents[3]
+            / "python/sglang/srt/layers/engram_nvme.cpp"
+        )
+        cls.library = cls.root / "rows.so"
+        subprocess.run(
+            [
+                "c++",
+                "-std=c++17",
+                "-O2",
+                "-shared",
+                "-fPIC",
+                "-pthread",
+                "-Wall",
+                "-Wextra",
+                "-Werror",
+                str(source),
+                "-o",
+                str(cls.library),
+            ],
+            check=True,
+        )
+        cls.lib = ctypes.CDLL(str(cls.library), use_errno=True)
+        cls.lib.row_store_open.argtypes = [ctypes.c_char_p] + [ctypes.c_uint64] * 4
+        cls.lib.row_store_open.restype = ctypes.c_void_p
+        cls.lib.row_store_close.argtypes = [ctypes.c_void_p]
+        cls.lib.row_store_lookup.argtypes = [ctypes.c_void_p]
+        cls.lib.row_store_range.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint64,
+            ctypes.c_uint64,
+        ]
+        cls.lib.row_store_stats.argtypes = [
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_uint64),
+        ]
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmp.cleanup()
+
+    def lookup(self, store, ids):
+        indices = (ctypes.c_int64 * len(ids))(*ids)
+        weights = (ctypes.c_uint8 * (len(ids) * 256))()
+        scales = (ctypes.c_uint8 * (len(ids) * 8))()
+        work = _Work(
+            store,
+            ctypes.addressof(indices),
+            ctypes.addressof(weights),
+            ctypes.addressof(scales),
+            len(ids),
+        )
+        self.lib.row_store_lookup(ctypes.byref(work))
+        return bytes(weights), bytes(scales)
+
+    def open(self, budget=0):
+        store = self.lib.row_store_open(
+            os.fsencode(self.shard), 257, self.woff, self.soff, budget
+        )
+        self.assertTrue(store, os.strerror(ctypes.get_errno()))
+        return store
+
+    def test_exact_rows_cache_collisions_ranges_and_concurrency(self):
+        rng = random.Random(919)
+        for slots in (0, 17, 257):
+            store = self.open(slots * 272)
+            try:
+                for lo, hi in ((0, 257), (11, 233)):
+                    self.lib.row_store_range(store, lo, hi)
+                    cases = [
+                        [rng.randrange(257) for _ in range(n)]
+                        for n in (0, 1, 24, 32, 33, 97, 2048)
+                    ]
+                    cases += [[0, 256, 0, 17, 34, 51] * 12]
+                    with ThreadPoolExecutor(max_workers=4) as pool:
+                        results = list(
+                            pool.map(lambda ids: self.lookup(store, ids), cases * 3)
+                        )
+                    for ids, (weight, scale) in zip(cases * 3, results):
+                        self.assertEqual(
+                            weight,
+                            b"".join(
+                                self.weights[i * 256 : (i + 1) * 256]
+                                if lo <= i < hi
+                                else bytes(256)
+                                for i in ids
+                            ),
+                        )
+                        self.assertEqual(
+                            scale,
+                            b"".join(
+                                self.scales[i * 8 : (i + 1) * 8]
+                                if lo <= i < hi
+                                else bytes(8)
+                                for i in ids
+                            ),
+                        )
+            finally:
+                self.lib.row_store_close(store)
+
+    def test_cache_accounting(self):
+        store = self.open(17 * 272 + 1)
+        try:
+            first = self.lookup(store, [2, 3])
+            self.assertEqual(first, self.lookup(store, [2, 3]))
+            stats = (ctypes.c_uint64 * 4)()
+            self.lib.row_store_stats(store, stats)
+            self.assertEqual(list(stats)[:2], [2, 2])
+            self.assertEqual(stats[3], 17 * 272)
+        finally:
+            self.lib.row_store_close(store)
+
+    def test_reject_missing_and_invalid_extents(self):
+        self.assertFalse(
+            self.lib.row_store_open(b"/nonexistent-engram-fixture", 257, 0, 0, 0)
+        )
+        self.assertFalse(
+            self.lib.row_store_open(os.fsencode(self.shard), 2**63, 0, 0, 0)
+        )
+
+    def test_invalid_id_and_truncation_fail_closed(self):
+        # Isolate deliberate aborts, and avoid writing core dumps in CI.
+        script = """
+import ctypes as c, json, os, resource, sys
+resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+library, shard, woff, soff, case = json.loads(sys.argv[1])
+lib = c.CDLL(library)
+lib.row_store_open.argtypes = [c.c_char_p] + [c.c_uint64] * 4
+lib.row_store_open.restype = c.c_void_p
+class Work(c.Structure):
+    _fields_ = [('store', c.c_void_p), ('ids', c.c_void_p), ('w', c.c_void_p), ('s', c.c_void_p), ('count', c.c_uint64)]
+store = lib.row_store_open(os.fsencode(shard), 257, woff, soff, 0)
+assert store
+if case == 'truncate': os.truncate(shard, soff)
+ids = (c.c_int64 * 1)(-1 if case == 'id' else 256)
+w, s = (c.c_uint8 * 256)(), (c.c_uint8 * 8)()
+work = Work(store, c.addressof(ids), c.addressof(w), c.addressof(s), 1)
+lib.row_store_lookup(c.byref(work))
+"""
+        for case in ("id", "truncate"):
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    script,
+                    json.dumps(
+                        [str(self.library), str(self.shard), self.woff, self.soff, case]
+                    ),
+                ],
+                capture_output=True,
+            )
+            self.assertEqual(result.returncode, -6, result.stderr)
+            fixture(self.root)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add an opt-in exact NVMe backend for DeepSeek-V4.1 Engram tables. Instead of allocating the complete embedding tables in GPU or host memory, the backend retrieves the original FP8 rows and E8M0 scales from a local indexed safetensors checkpoint, using a bounded RAM row cache and pinned staging.

Based on `dsv4.1-lkmoe-sm80plus` at `fe4e73001b9967c8c92fe655cd27d774709665e3`. The default GPU and host-table paths are retained. This does not change Engram hashing, gating, projection, or dequantization math.

## Changes

- Add an explicit `SGLANG_ENABLE_DSV41_ENGRAM_NVME` option and per-layer cache/staging byte budgets through the existing environment configuration system.
- Integrate storage into `EngramEmbedding` initialization, weight validation and owned-row lookup; no import hooks or monkey patches.
- Validate local checkpoint layout, table dtype/shape, byte extents, and shard location before opening storage.
- Deduplicate 4KiB pages and submit bounded Linux native-AIO batches, at most 32 rows / 128 pages at a time. Preserve exact bytes, including cross-page and final partial-page reads.
- Build the native C++ reader from packaged source through PyTorch's extension loader; no precompiled binaries or machine paths.
- Keep host callbacks free of CUDA API calls. Retain captured storage for the worker lifetime, synchronize eager cleanup, and reject model weight reload before consuming replacement weights.
- Add CPU storage tests, a small CUDA integration/graph test, and usage documentation linked from both READMEs.

## Validation

PR implementation, tested in an isolated source directory on Linux / RTX PRO 5000 72GB (SM120), without loading a second model:

- 11 CPU tests passed: metadata/configuration rejection, exact row bytes, cache collisions/accounting, ownership ranges, concurrent native calls, invalid IDs and truncated files.
- 6 CUDA tests passed: eager lookup, empty/multi-batch requests, pending-callback cleanup, staging guards, real `EngramEmbedding` integration, default-path allocation and early reload rejection.
- CUDA graph test includes 24 exact-reference replays after dropping the caller's Python store reference.
- Native reader compiled with `-Wall -Wextra -Werror` in the CPU test; the CUDA tests also exercise the PyTorch extension build path.
- Syntax checks, targeted Ruff/isort checks, clang-format and `git diff --check` passed. The generated patch applies cleanly to the stated base.
- No model-wide accuracy evaluation or full-model benchmark has been run on this PR branch. The deployed field implementation remains unchanged.

## Speed tests and profiling

The original field adapter's deterministic reader microbenchmark improved from 4.4173ms (serial) to 0.3932ms (batched) per 24-row callback with the row cache disabled and matching output hashes.

A separate deployed 16K-input / 2K-output run improved from 15.97 to 29.62 tokens/s, but included scale residency and a NUMA workaround. Those changes are excluded here, and the deployment used an older base and different scheduling settings. **These figures are background evidence, not benchmarks of this isolated PR.** Full-model throughput verification remains pending.

## Scope and limitations

- Experimental Linux/CUDA support, currently single worker / TP=PP=1, one running request, overlap scheduling disabled, no speculative decoding or torch.compile.
- Local immutable checkpoint only; 256-wide FP8 rows and eight E8M0 scales, stored together per layer. Unsupported configurations/layouts are rejected.
- Backing storage must support direct I/O and native AIO. Runtime I/O failure aborts the worker rather than returning stale bytes.
- Captured stores and buffers live until worker exit; hot-swapping models and concurrent multi-stream graph replay are unsupported.
- CPU MoE weights and load-time temporaries still need sufficient RAM. This backend alone does not guarantee that a full model fits on a 256GiB host.
- Does not include optional scale residency, FP4 checkpoint-load staging, NUMA interposition, FP8 tuning or the field adapter's SM120 Indexer workaround.

## Follow-up work

- Complete model-level loading, accuracy and throughput validation on the selected base.
- Evaluate portable scale residency and loader-memory controls separately.
- Extend supported concurrency/parallelism only with lifecycle and graph coverage.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34715064705](https://github.com/guqiong96/Lsglang/actions/runs/34715064705)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34715064662](https://github.com/guqiong96/Lsglang/actions/runs/34715064662)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34715064756](https://github.com/guqiong96/Lsglang/actions/runs/34715064756)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

---
Superseded by https://github.com/guqiong96/Lsglang/pull/28, rebased onto the latest DSV4.1 branch with guarded fixed-width DSpark integration, optional SM120 b12x dispatch, focused tests and M=4/M=6 component benchmarks. Closing this earlier draft to keep Engram review in one place. The independent prefill-memory change is in #27.